### PR TITLE
fixed CK sort

### DIFF
--- a/ck_api_data/index.html
+++ b/ck_api_data/index.html
@@ -8,7 +8,7 @@
     <div id="buttonWrapper" class="buttonWrapper">
         <button id="getPrices" class="getPrices" onclick="jsonWorker()">Get Prices</button>
         <button id="filterCards" class="filterCards" onclick="filterWorker()">Filter Cards</button>
-        <button id="clearFilters" class="clearFilters" onclick="clearFilers()">Clear Filters</button>
+        <button id="clearFilters" class="clearFilters" onclick="clearDisplayData()">Clear Display Data</button>
     </div>
     <div id="repriceTimestamp" class="repriceTimestamp">&nbsp;</div>
     <br />
@@ -24,6 +24,6 @@
     <script src="modules/curlModule.js" ></script>
     <script src="modules/filterModule.js" ></script>
     <!-- Testing Only -->
-    <script src="testArr.js"></script>
+    <script src="json/testJson.js" ></script>
 </body>
 </html>

--- a/ck_api_data/js/genericFunctions.js
+++ b/ck_api_data/js/genericFunctions.js
@@ -4,4 +4,6 @@ const writeToDisplay = (msg) => document.getElementById("listDisplay").innerHTML
 
 const writeError = (err) => console.log("There was an error: "+err);
 
-const loaderDisplay = () => document.getElementById("loader").style.display = document.getElementById("loader").style.display === "none" || document.getElementById("loader").style.display === "" ? "inherit" : "none";
+const loaderDisplay = () => document.getElementById("loader").style.display = (document.getElementById("loader").style.display === "none" || document.getElementById("loader").style.display === "") ? "inherit" : "none";
+
+const clearDisplayData = () => document.getElementById("listDisplay").innerHTML = '';

--- a/ck_api_data/json/sample.json
+++ b/ck_api_data/json/sample.json
@@ -15,6 +15,7 @@
       "price_retail": "0.25",
       "qty_retail": 17,
       "price_buy": "0.05",
+      "qty_buying": 1
     },
     {
       "id": 10001,

--- a/ck_api_data/json/testJson.js
+++ b/ck_api_data/json/testJson.js
@@ -1,0 +1,112 @@
+const testJson = () => (
+    {
+        "meta": {
+        "created_at": "2020-03-07 17:01:39",
+            "base_url": "https://www.cardkingdom.com/"
+    },
+    "data": [
+    {
+        "id": 10000,
+        "sku": "4ED-117",
+        "url": "mtg/4th-edition/abomination",
+        "name": "Abomination",
+        "variation": "",
+        "edition": "4th Edition",
+        "is_foil": "false",
+        "price_retail": "0.25",
+        "qty_retail": 17,
+        "price_buy": "0.05",
+        "qty_buying": 1
+    },
+    {
+        "id": 10001,
+        "sku": "4ED-117",
+        "url": "mtg/4th-edition/abomination",
+        "name": "Island",
+        "variation": "",
+        "edition": "4th Edition",
+        "is_foil": "false",
+        "price_retail": "0.25",
+        "qty_retail": 17,
+        "price_buy": "0.05",
+        "qty_buying": 1
+    },
+    {
+        "id": 10190,
+        "sku": "4ED-117",
+        "url": "mtg/4th-edition/abomination",
+        "name": "Lightning Bolt",
+        "variation": "",
+        "edition": "4th Edition",
+        "is_foil": "false",
+        "price_retail": "0.25",
+        "qty_retail": 17,
+        "price_buy": "0.05",
+        "qty_buying": 1
+    },
+    {
+        "id": 10003,
+        "sku": "4ED-117",
+        "url": "mtg/4th-edition/abomination",
+        "name": "Swamp",
+        "variation": "",
+        "edition": "4th Edition",
+        "is_foil": "false",
+        "price_retail": "0.25",
+        "qty_retail": 17,
+        "price_buy": "0.05",
+        "qty_buying": 1
+    },
+    {
+        "id": 10004,
+        "sku": "4ED-117",
+        "url": "mtg/4th-edition/abomination",
+        "name": "Abomination",
+        "variation": "",
+        "edition": "5th Edition",
+        "is_foil": "false",
+        "price_retail": "0.25",
+        "qty_retail": 17,
+        "price_buy": "0.05",
+        "qty_buying": 1
+    },
+    {
+        "id": 10005,
+        "sku": "4ED-117",
+        "url": "mtg/4th-edition/abomination",
+        "name": "Island",
+        "variation": "",
+        "edition": "5th Edition",
+        "is_foil": "false",
+        "price_retail": "0.25",
+        "qty_retail": 17,
+        "price_buy": "0.05",
+        "qty_buying": 1
+    },
+    {
+        "id": 13147,
+        "sku": "4ED-117",
+        "url": "mtg/4th-edition/abomination",
+        "name": "Lightning Bolt",
+        "variation": "",
+        "edition": "Unlimited",
+        "is_foil": "false",
+        "price_retail": "0.25",
+        "qty_retail": 17,
+        "price_buy": "0.05",
+        "qty_buying": 1
+    },
+    {
+        "id": 10007,
+        "sku": "4ED-117",
+        "url": "mtg/4th-edition/abomination",
+        "name": "Swamp",
+        "variation": "",
+        "edition": "5th Edition",
+        "is_foil": "false",
+        "price_retail": "0.25",
+        "qty_retail": 17,
+        "price_buy": "0.05",
+        "qty_buying": 1
+    }]
+});

--- a/ck_api_data/modules/displayModule.js
+++ b/ck_api_data/modules/displayModule.js
@@ -7,13 +7,12 @@ const jsonWorker = () => {
 
 const startDisplayOutput = (json) => {
     updateAPITimestamp(json.meta.created_at);
-    displayData(createCKData(json));
+    createCKData(json);
+    loaderDisplay();
+    writeToDisplay("CK inventory has been gathered, you can now filter your data.");
 }
 
-const createCKData = (json) => {
-    json.data.forEach(data => ckData[data.id] = data);
-    return ckData;
-}
+const createCKData = (json) => json.data.forEach(data => ckData[data.id] = data);
 
 const updateAPITimestamp = (timestamp) => document.getElementById("repriceTimestamp").innerHTML = "<br /><strong>CK API Last Updated:</strong> "+timestamp;
 

--- a/ck_api_data/modules/filterModule.js
+++ b/ck_api_data/modules/filterModule.js
@@ -1,8 +1,7 @@
 const filterWorker = () => {
-    const filterList = cleanFilter(getFilters());
     writeToDisplay("Filtering your data.");
     loaderDisplay();
-    filterTable(filterList);
+    filterTable(cleanFilter(getFilters()));
 }
 
 const getFilters = () => document.getElementById("cardNames").value.split("\n");
@@ -11,9 +10,12 @@ const cleanFilter = (filterList) => filterList.map(cardName => cardName.replace(
 
 const cleanCkCardName = (card) => card.replace(/\W/g,'').toLowerCase();
 
-const clearFilers= () => document.getElementById("listDisplay").innerHTML = '';
-
+/*
+    CK sorts cards by SKU and those SKUs are not in MtG Chronolical order
+    To "fix" this and enable easier data display, we sort the output display
+    alphabetically by card name.
+ */
 const filterTable = (filterList) => {
     const filteredCardList = ckData.filter( curCard => filterList.includes(cleanCkCardName(curCard.name) ));
-    displayData(filteredCardList.sort());
+    displayData(filteredCardList.sort( (firstCard, secondCard) => (firstCard.name > secondCard.name) ? 1 : ((secondCard.name > firstCard.name) ? -1 : 0)));
 }


### PR DESCRIPTION
CK inventory is sorted by SKU which is not representative of historical MtG releases.
- Updated the sort of filtered results to be alphabetical by SKU

Found and addressed issue with delay in functionality after display of the CK API data.
- Displaying data was causing issues with followup onClick() functions meant to update the data display
- Removed display of the initial data set and replaced it with an alert to the user that they may now begin filtering their data