### PR TITLE
added a ceil

### DIFF
--- a/tampermonkey_scripts/js/TCG_Player_Sales_Display_Data.js
+++ b/tampermonkey_scripts/js/TCG_Player_Sales_Display_Data.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TCG Player Sales Display Data
 // @namespace    https://www.tcgplayer.com/
-// @version      0.21
+// @version      0.22
 // @description  Remove obfuscation around TCG Player Sales Data
 // @author       Peter Creutzberger
 // @match        https://www.tcgplayer.com/product/*
@@ -219,7 +219,7 @@
         return new Date(dateArr[2], dateArr[0] - 1, dateArr[1]);
     }
 
-    const getSaleDateDiff = (firstDate, secondDate) => (parseStrDate(firstDate) - parseStrDate(secondDate)) / daysInMilliseconds(1);
+    const getSaleDateDiff = (firstDate, secondDate) => Math.ceil((parseStrDate(firstDate) - parseStrDate(secondDate)) / daysInMilliseconds(1) );
 
     const daysInMilliseconds = (days = 1) => 1000 * 60 * 60 * (24 * days);
 


### PR DESCRIPTION
Checking sales on the first of the month yielded historic sales dates ~0.06 less than the whole number they should have been. (.94... instead of 1, 1.94 instead of two) so the sales date diff result has been wrapped in a Math.ceil() to fix the issue.