### PR TITLE
extended row highlight to un-highlight

### DIFF
--- a/ck_api_data/modules/tableDisplayUpdates.js
+++ b/ck_api_data/modules/tableDisplayUpdates.js
@@ -1,3 +1,3 @@
 const setBackgroundColor = (row) => {
-    row.forEach( cell => cell.style.backgroundColor = 'darkorange');
+    row.forEach( cell => cell.style.backgroundColor = cell.style.backgroundColor === '' ? 'darkorange' : '');
 }


### PR DESCRIPTION
Added a conditional check to the function that "locks" a row by changing the background color to remove that color when the row is clicked again. This allows the user to both "lock" and "unlock" the row.