### PR TITLE
reenabled live slug option

### DIFF
--- a/ck_api_data/index.html
+++ b/ck_api_data/index.html
@@ -9,7 +9,7 @@
         <button id="getPrices" class="getPrices" onclick="jsonGetWorker(fetchBuylist)">Get Prices</button>
         <button id="filterCards" class="filterCards" disabled onclick="filterCardInputListWorker('buylist')">Filter Cards</button>
         <input type="checkbox" class="showZeros" id="showZeros" checked/><label for="showZeros">Show Zeros</label>
-        <input type="checkbox" class="whichSlug" id="whichSlug" /><label for="whichSlug">Use Live Slug</label>
+        <input type="checkbox" class="whichSlug" id="whichSlug" checked/><label for="whichSlug">Use Live Slug</label>
     </div>
     <br />
     <div id="showPercentWrapped" class="showPercentWrapped">


### PR DESCRIPTION
Re-enabled "live slug" as default data pull option.