### PR TITLE
qty update aded

### DIFF
--- a/tampermonkey_scripts/js/TCG_Player_Sales_Display_Data.js
+++ b/tampermonkey_scripts/js/TCG_Player_Sales_Display_Data.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         TCG Player Sales Display Data
 // @namespace    https://www.tcgplayer.com/
-// @version      0.46
+// @version      0.47
 // @description  Remove obfuscation around TCG Player Sales Data
 // @author       Peter Creutzberger
 // @match        https://www.tcgplayer.com/product/*
@@ -196,7 +196,7 @@
             qtyInView[shorthandCondition].vendorCount += 1;
             if( !qtyInView[shorthandCondition].largestQuantity || qtyInView[shorthandCondition].largestQuantity < qty) { qtyInView[shorthandCondition].largestQuantity = qty; }
         }
-        else { qtyInView[shorthandCondition] = {quantity: qty, vendorCount: 1, largestQuantity: 0}; }
+        else { qtyInView[shorthandCondition] = {quantity: qty, vendorCount: 1, largestQuantity: qty}; }
     }
 
     const mapCondition = (condition) => {


### PR DESCRIPTION
Code improperly set the first instance of a conditions largest quantity to 0 instead of the found quantity. This lead to issues where when only one listing of a condition existed on the page, the displayed quantity remained 0.

Updated the code to use found quantity upon adding the first instance of a condition to the object.